### PR TITLE
fix panic that occurs for aks 1.24.10 meta.db

### DIFF
--- a/db.go
+++ b/db.go
@@ -167,7 +167,9 @@ func Open(path string, options *Options) (*DB, error) {
 
 	// Read in the freelist.
 	db.freelist = newFreelist()
-	db.freelist.read(db.page(db.meta().freelist))
+	if !db.readOnly {
+		db.freelist.read(db.page(db.meta().freelist))
+	}
 
 	// Mark the database as opened and return.
 	return db, nil


### PR DESCRIPTION
The /var/lib/containerd/io.containerd.metadata.v1.bolt/meta.db file changed in AKS 1.24.10 and is now something that this library cannot open. A panic occurs because the code here tries to operate on its freelist when the freelist is invalid. Since the freelist is only used in write mode, we can add a condition to not initialize the freelist if we’re opening the file in read-only mode.